### PR TITLE
fix: resolve upload:// tokens to CDN URLs via Base62 decode

### DIFF
--- a/raw-edition/content.js
+++ b/raw-edition/content.js
@@ -901,8 +901,29 @@
     }
   }
 
+  // Discourse Base62 解码：将 upload:// token 还原为 SHA1 hex
+  // Discourse 使用 charset "0-9 a-z A-Z" 对 SHA1 做 Base62 编码生成 upload:// 短链
+  // 解码后即可与 CDN URL 中的 hex SHA1 精确匹配
+  function base62ToSha1Hex(base62Str) {
+    const CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    try {
+      let num = 0n;
+      for (const ch of base62Str) {
+        const idx = CHARSET.indexOf(ch);
+        if (idx === -1) return null;
+        num = num * 62n + BigInt(idx);
+      }
+      const hex = num.toString(16).padStart(40, '0');
+      // SHA1 固定 40 位 hex；超长说明输入不合法
+      return hex.length === 40 ? hex : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
   // V5.5-raw: 将 cooked HTML 中的图片 URL 映射回 raw 的 upload:// token
   // V5.5.4: 修复当 cookedHtml 为空时直接返回导致 upload:// 残留的 bug
+  // V5.5.5: Base62→SHA1 精确匹配，大幅提升 CDN URL 命中率
   function resolveUploadUrls(rawMarkdown, cookedHtml) {
     if (!rawMarkdown) return rawMarkdown;
     // 找出 raw 中所有 upload:// token
@@ -910,24 +931,40 @@
     if (!uploadTokens || uploadTokens.length === 0) return rawMarkdown;
 
     // 从 cooked HTML 提取所有 CDN URL（img src、a href、audio/source/video src）
+    // 匹配 /uploads/、/original/、/optimized/ 三种路径格式：
+    //   标准 Discourse:  https://site.com/uploads/default/original/1X/sha1.ext
+    //   CDN 模式 (如 linux.do): https://cdn3.linux.do/original/4X/sha1.ext
     const imgUrls = [];
-    const allUrlRegex = /(?:src|href)="(https?:\/\/[^"]+\/uploads\/[^"]+)"/g;
+    const allUrlRegex = /(?:src|href)="(https?:\/\/[^"]+\/(?:uploads|original|optimized)\/[^"]+)"/g;
     let m;
     while ((m = allUrlRegex.exec(cookedHtml)) !== null) {
       if (!imgUrls.includes(m[1])) imgUrls.push(m[1]);
     }
 
     let resolved = rawMarkdown;
-    uploadTokens.forEach((token, idx) => {
+    // 去重避免重复处理同一 token
+    const uniqueTokens = [...new Set(uploadTokens)];
+    uniqueTokens.forEach((token) => {
       // 取 upload:// 后的 hash（去掉扩展名）
       const tokenBody = token.replace('upload://', '');
       const hashPart = tokenBody.split('.')[0];
 
-      // 优先：在 URL 中找到包含此 hash 的完整 URL
-      const matchedUrl = imgUrls.find(u => u.includes(hashPart));
+      let matchedUrl = null;
+
+      // 策略1: Base62 解码为 SHA1 hex，精确匹配 CDN URL（命中率最高）
+      // upload://6DIL0Ab7QpYNqdW6kf54aAZQ9x0 → sha1 hex → 在 CDN URL 中查找
+      const sha1Hex = base62ToSha1Hex(hashPart);
+      if (sha1Hex) {
+        matchedUrl = imgUrls.find(u => u.includes(sha1Hex));
+      }
+
+      // 策略2: token hash 子串直接匹配（兼容非标准 URL 格式）
+      if (!matchedUrl) {
+        matchedUrl = imgUrls.find(u => u.includes(hashPart));
+      }
+
       // V5.5.3: fallback → /uploads/short-url/ 确保 upload:// 一定被替换
       const replacement = matchedUrl ||
-        (idx < imgUrls.length ? imgUrls[idx] : null) ||
         window.location.origin + '/uploads/short-url/' + tokenBody;
       resolved = resolved.split(token).join(replacement);
     });


### PR DESCRIPTION
## Summary

- **新增 `base62ToSha1Hex()`**：将 Discourse `upload://` token（Base62 编码）解码回 SHA1 hex，与 CDN URL 精确匹配
- **修正 CDN URL 提取正则**：增加 `/original/`、`/optimized/` 路径匹配，覆盖 CDN 模式站点（如 linux.do 使用 `cdn3.ldstatic.com/original/...`）
- **移除不可靠的序号盲配**：旧逻辑按 index 兜底容易错配，现在仅保留精确匹配 + short-url fallback

### 问题背景

`resolveUploadUrls` 用于将 raw Markdown 中的 `upload://` token 替换为可访问的图片 URL。旧实现用 Base62 字符串对 CDN URL 做子串匹配（`u.includes(hashPart)`），但 CDN URL 中存储的是 SHA1 hex——两种编码完全不同，几乎不可能命中：

```
upload://6DIL0Ab7QpYNqdW6kf54aAZQ9x0.png   ← Base62
cdn3.ldstatic.com/.../2e8a8721f7d340d7...png ← SHA1 hex (同一个哈希)
```

同时正则只匹配 `/uploads/` 路径，但 linux.do 等 CDN 站点的图片路径是 `/original/` 和 `/optimized/`，导致提取到 0 个 CDN URL。

### 修复方案

1. Base62 → BigInt → hex，得到 40 位 SHA1，在 CDN URL 中精确 `includes` 匹配
2. 正则扩展为 `/(?:uploads|original|optimized)/`

### 已验证

在 linux.do 帖子（含 3 张 upload:// 图片）上控制台验证，修复前 0/3 匹配，修复后 3/3 全部命中 CDN URL。

## Test plan

- [ ] 在 linux.do 帖子页面保存，确认图片 URL 为 CDN 格式（非 short-url）
- [ ] 在标准 Discourse 站点（如 meta.discourse.org）测试，确认 `/uploads/` 路径仍正常匹配
- [ ] 测试无图片帖子，确认不报错
- [ ] 测试 cookedHtml 为空的降级场景，确认 fallback 到 short-url

🤖 Generated with [Claude Code](https://claude.com/claude-code)